### PR TITLE
feat: ability to control padding in models

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -26,14 +26,11 @@ jobs:
             python -m pip install --upgrade pip
             pip install .[lint]
 
-        - name: Run Black
-          run: black --check .
+        - name: Run Ruff Lint
+          run: ruff check .
 
-        - name: Run isort
-          run: isort --check-only .
-
-        - name: Run flake8
-          run: flake8 .
+        - name: Run Ruff Format
+          run: ruff format --check .
 
         - name: Run mdformat
           run: mdformat . --check

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,25 +4,15 @@ repos:
     hooks:
     -   id: check-yaml
 
--   repo: https://github.com/PyCQA/isort
-    rev: 6.0.1
+-   repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.12.0  # Latest ruff version
     hooks:
-      - id: isort
-
--   repo: https://github.com/psf/black
-    rev: 25.1.0
-    hooks:
-      - id: black
-        name: black
-
--   repo: https://github.com/pycqa/flake8
-    rev: 7.2.0
-    hooks:
-    -   id: flake8
-        additional_dependencies: [flake8-breakpoint, flake8-print, flake8-pydantic, flake8-type-checking]
+    -   id: ruff
+        args: [--fix, --exit-non-zero-on-fix]
+    -   id: ruff-format
 
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.15.0
+    rev: v1.16.1
     hooks:
     -   id: mypy
         additional_dependencies: [types-setuptools, pydantic]

--- a/README.md
+++ b/README.md
@@ -134,3 +134,8 @@ class MyModel(BaseModel):
         field_type = cls.model_fields[info.field_name].annotation
         return field_type.__eth_pydantic_validate__(value, pad=Pad.RIGHT)
 ```
+
+Else, by default, if you validate integer values, it will pad left.
+Other inputs pad right.
+This mirrors Solidity types, like `bytes32`, that automatically pad-right when given smaller values.
+Integer and address types automatically pad-left.

--- a/README.md
+++ b/README.md
@@ -114,3 +114,23 @@ message = Message(
     )
 )
 ```
+
+## Padding
+
+For types like `HexStr` or `HexBytes`, you can control the padding by using `@field_validator()`.
+
+```python
+from pydantic import BaseModel, field_validator
+from eth_pydantic_types import HexStr20, HexBytes20
+from eth_pydantic_types.utils import Pad
+
+class MyModel(BaseModel):
+    my_str: HexStr20
+    my_bytes: HexBytes20
+
+    @field_validator("my_str", "my_bytes", mode="before")
+    @classmethod
+    def validate_value(cls, value, info):
+        field_type = cls.model_fields[info.field_name].annotation
+        return field_type.__eth_pydantic_validate__(value, pad=Pad.RIGHT)
+```

--- a/eth_pydantic_types/abi.py
+++ b/eth_pydantic_types/abi.py
@@ -2,10 +2,10 @@
 These models are used to match the lowercase type names used by the abi.
 """
 
-from typing import ClassVar
+from typing import Annotated, ClassVar
 
 from pydantic import Field
-from typing_extensions import Annotated, TypeAliasType
+from typing_extensions import TypeAliasType
 
 from .address import Address
 from .hex import BoundHexBytes, HexBytes

--- a/eth_pydantic_types/address.py
+++ b/eth_pydantic_types/address.py
@@ -43,7 +43,9 @@ class Address(HexStr20):
         )
 
     @classmethod
-    def __eth_pydantic_validate__(cls, value: Any, info: Optional[ValidationInfo] = None) -> str:
+    def __eth_pydantic_validate__(
+        cls, value: Any, info: Optional[ValidationInfo] = None, **kwargs
+    ) -> str:
         value = super().__eth_pydantic_validate__(value)
         return cls.to_checksum_address(value)
 

--- a/eth_pydantic_types/bip122.py
+++ b/eth_pydantic_types/bip122.py
@@ -32,7 +32,9 @@ class Bip122Uri(str):
             f"/{Bip122UriType.BLOCK.value}/"
             f"752820c0ad7abc1200f9ad42c4adc6fbb4bd44b5bed4667990e64565102c1ba6"
         )
-        pattern = f"^{cls.prefix}[0-9a-f]{{64}}/{Bip122UriType.BLOCK.value}/[0-9a-f]{{64}}$"
+        pattern = (
+            f"^{cls.prefix}[0-9a-f]{{64}}/{Bip122UriType.BLOCK.value}/[0-9a-f]{{64}}$"
+        )
         json_schema.update(examples=[example], pattern=pattern)
         return json_schema
 
@@ -44,7 +46,9 @@ class Bip122Uri(str):
         )
 
     @classmethod
-    def __eth_pydantic_validate__(cls, value: Any, info: Optional[ValidationInfo] = None) -> str:
+    def __eth_pydantic_validate__(
+        cls, value: Any, info: Optional[ValidationInfo] = None, **kwargs
+    ) -> str:
         if not value.startswith(cls.prefix):
             raise Bip122UriFormatError(value)
 

--- a/eth_pydantic_types/bip122.py
+++ b/eth_pydantic_types/bip122.py
@@ -32,9 +32,7 @@ class Bip122Uri(str):
             f"/{Bip122UriType.BLOCK.value}/"
             f"752820c0ad7abc1200f9ad42c4adc6fbb4bd44b5bed4667990e64565102c1ba6"
         )
-        pattern = (
-            f"^{cls.prefix}[0-9a-f]{{64}}/{Bip122UriType.BLOCK.value}/[0-9a-f]{{64}}$"
-        )
+        pattern = f"^{cls.prefix}[0-9a-f]{{64}}/{Bip122UriType.BLOCK.value}/[0-9a-f]{{64}}$"
         json_schema.update(examples=[example], pattern=pattern)
         return json_schema
 

--- a/eth_pydantic_types/hex/base.py
+++ b/eth_pydantic_types/hex/base.py
@@ -1,6 +1,5 @@
 from typing import ClassVar
 
-
 schema_pattern = "^0x([0-9a-f][0-9a-f])*$"
 schema_examples = (
     "0x",  # empty bytes

--- a/eth_pydantic_types/hex/base.py
+++ b/eth_pydantic_types/hex/base.py
@@ -1,5 +1,6 @@
 from typing import ClassVar
 
+
 schema_pattern = "^0x([0-9a-f][0-9a-f])*$"
 schema_examples = (
     "0x",  # empty bytes
@@ -21,6 +22,8 @@ class BaseHex:
     def __get_pydantic_json_schema__(cls, core_schema, handler):
         json_schema = handler(core_schema)
         json_schema.update(
-            format="binary", pattern=cls.schema_pattern, examples=list(cls.schema_examples)
+            format="binary",
+            pattern=cls.schema_pattern,
+            examples=list(cls.schema_examples),
         )
         return json_schema

--- a/eth_pydantic_types/hex/bytes.py
+++ b/eth_pydantic_types/hex/bytes.py
@@ -29,9 +29,7 @@ class HexBytes(BaseHexBytes, BaseHex):
 
     @classmethod
     def __get_pydantic_core_schema__(cls, value, handle=None) -> "CoreSchema":
-        schema = with_info_before_validator_function(
-            cls.__eth_pydantic_validate__, bytes_schema()
-        )
+        schema = with_info_before_validator_function(cls.__eth_pydantic_validate__, bytes_schema())
         schema["serialization"] = hex_serializer
         return schema
 
@@ -53,9 +51,7 @@ class HexBytes(BaseHexBytes, BaseHex):
         return cls(cls.validate_size(HexBytes(value), pad_direction=pad))
 
     @classmethod
-    def validate_size(
-        cls, value: bytes, pad_direction: PadDirection = PadDirection.LEFT
-    ) -> bytes:
+    def validate_size(cls, value: bytes, pad_direction: PadDirection = PadDirection.LEFT) -> bytes:
         return value
 
 
@@ -77,9 +73,7 @@ class BoundHexBytes(HexBytes):
         return schema
 
     @classmethod
-    def validate_size(
-        cls, value: bytes, pad_direction: PadDirection = PadDirection.LEFT
-    ) -> bytes:
+    def validate_size(cls, value: bytes, pad_direction: PadDirection = PadDirection.LEFT) -> bytes:
         str_size = cls.size * 2
         cls.schema_pattern = get_hash_pattern(str_size)
         cls.schema_examples = get_hash_examples(str_size)

--- a/eth_pydantic_types/hex/bytes.py
+++ b/eth_pydantic_types/hex/bytes.py
@@ -29,7 +29,9 @@ class HexBytes(BaseHexBytes, BaseHex):
 
     @classmethod
     def __get_pydantic_core_schema__(cls, value, handle=None) -> "CoreSchema":
-        schema = with_info_before_validator_function(cls.__eth_pydantic_validate__, bytes_schema())
+        schema = with_info_before_validator_function(
+            cls.__eth_pydantic_validate__, bytes_schema()
+        )
         schema["serialization"] = hex_serializer
         return schema
 
@@ -40,17 +42,20 @@ class HexBytes(BaseHexBytes, BaseHex):
 
     @classmethod
     def __eth_pydantic_validate__(
-        cls, value: Any, info: Optional[ValidationInfo] = None
+        cls,
+        value: Any,
+        info: Optional[ValidationInfo] = None,
+        **kwargs,
     ) -> BaseHexBytes:
-
-        # NOTE: We only left-pad integers. All other bytes values are right-padded
-        #   to be compliant with ABI encoding.
-        pad = PadDirection.LEFT if isinstance(value, int) else PadDirection.RIGHT
+        if not (pad := kwargs.pop("pad", None)):
+            pad = PadDirection.LEFT if isinstance(value, int) else PadDirection.RIGHT
 
         return cls(cls.validate_size(HexBytes(value), pad_direction=pad))
 
     @classmethod
-    def validate_size(cls, value: bytes, pad_direction: PadDirection = PadDirection.LEFT) -> bytes:
+    def validate_size(
+        cls, value: bytes, pad_direction: PadDirection = PadDirection.LEFT
+    ) -> bytes:
         return value
 
 
@@ -72,7 +77,9 @@ class BoundHexBytes(HexBytes):
         return schema
 
     @classmethod
-    def validate_size(cls, value: bytes, pad_direction: PadDirection = PadDirection.LEFT) -> bytes:
+    def validate_size(
+        cls, value: bytes, pad_direction: PadDirection = PadDirection.LEFT
+    ) -> bytes:
         str_size = cls.size * 2
         cls.schema_pattern = get_hash_pattern(str_size)
         cls.schema_examples = get_hash_examples(str_size)

--- a/eth_pydantic_types/hex/int.py
+++ b/eth_pydantic_types/hex/int.py
@@ -24,18 +24,14 @@ if TYPE_CHECKING:
 class BaseHexInt(int, BaseHex):
     @classmethod
     def __get_pydantic_core_schema__(cls, value, handler=None):
-        return no_info_before_validator_function(
-            cls.__eth_pydantic_validate__, int_schema()
-        )
+        return no_info_before_validator_function(cls.__eth_pydantic_validate__, int_schema())
 
     @classmethod
     def __eth_pydantic_validate__(cls, value, **kwargs):
         return value  # Override.
 
     @classmethod
-    def from_bytes(
-        cls, data, byteorder: str = "big", signed: bool = False
-    ) -> "BaseHexInt":
+    def from_bytes(cls, data, byteorder: str = "big", signed: bool = False) -> "BaseHexInt":
         int_value = int.from_bytes(data, byteorder="big", signed=signed)
         return cls(int_value)
 
@@ -61,9 +57,7 @@ class HexInt(BaseHexInt):
 
     @classmethod
     def __get_pydantic_core_schema__(cls, value, handler=None) -> "CoreSchema":
-        schema = with_info_before_validator_function(
-            cls.__eth_pydantic_validate__, int_schema()
-        )
+        schema = with_info_before_validator_function(cls.__eth_pydantic_validate__, int_schema())
         schema["serialization"] = hex_serializer
         return schema
 

--- a/eth_pydantic_types/hex/int.py
+++ b/eth_pydantic_types/hex/int.py
@@ -24,14 +24,18 @@ if TYPE_CHECKING:
 class BaseHexInt(int, BaseHex):
     @classmethod
     def __get_pydantic_core_schema__(cls, value, handler=None):
-        return no_info_before_validator_function(cls.__eth_pydantic_validate__, int_schema())
+        return no_info_before_validator_function(
+            cls.__eth_pydantic_validate__, int_schema()
+        )
 
     @classmethod
-    def __eth_pydantic_validate__(cls, value):
+    def __eth_pydantic_validate__(cls, value, **kwargs):
         return value  # Override.
 
     @classmethod
-    def from_bytes(cls, data, byteorder: str = "big", signed: bool = False) -> "BaseHexInt":
+    def from_bytes(
+        cls, data, byteorder: str = "big", signed: bool = False
+    ) -> "BaseHexInt":
         int_value = int.from_bytes(data, byteorder="big", signed=signed)
         return cls(int_value)
 
@@ -57,12 +61,16 @@ class HexInt(BaseHexInt):
 
     @classmethod
     def __get_pydantic_core_schema__(cls, value, handler=None) -> "CoreSchema":
-        schema = with_info_before_validator_function(cls.__eth_pydantic_validate__, int_schema())
+        schema = with_info_before_validator_function(
+            cls.__eth_pydantic_validate__, int_schema()
+        )
         schema["serialization"] = hex_serializer
         return schema
 
     @classmethod
-    def __eth_pydantic_validate__(cls, value: Any, info: Optional[ValidationInfo] = None) -> int:
+    def __eth_pydantic_validate__(
+        cls, value: Any, info: Optional[ValidationInfo] = None, **kwargs
+    ) -> int:
         return cls(cls.validate_hex(value))
 
 
@@ -87,7 +95,9 @@ class BoundHexInt(BaseHexInt):
         )
 
     @classmethod
-    def __eth_pydantic_validate__(cls, value: Any, info: Optional[ValidationInfo] = None) -> int:
+    def __eth_pydantic_validate__(
+        cls, value: Any, info: Optional[ValidationInfo] = None, **kwargs
+    ) -> int:
         hex_int = cls.validate_hex(value)
         sized_value = cls.validate_size(hex_int)
         return cls(sized_value)

--- a/eth_pydantic_types/hex/str.py
+++ b/eth_pydantic_types/hex/str.py
@@ -3,8 +3,8 @@ from typing import TYPE_CHECKING, Any, ClassVar, Optional, Union
 from hexbytes.main import HexBytes as BaseHexBytes
 from pydantic_core.core_schema import (
     ValidationInfo,
-    str_schema,
     no_info_before_validator_function,
+    str_schema,
     with_info_before_validator_function,
 )
 
@@ -26,9 +26,7 @@ if TYPE_CHECKING:
 class BaseHexStr(str, BaseHex):
     @classmethod
     def __get_pydantic_core_schema__(cls, value, handler=None):
-        return no_info_before_validator_function(
-            cls.__eth_pydantic_validate__, str_schema()
-        )
+        return no_info_before_validator_function(cls.__eth_pydantic_validate__, str_schema())
 
     @classmethod
     def __eth_pydantic_validate__(cls, value, **kwargs):
@@ -115,9 +113,7 @@ class BoundHexStr(BaseHexStr):
         return cls(f"0x{sized_value}")
 
     @classmethod
-    def validate_size(
-        cls, value: str, pad_direction: PadDirection = PadDirection.LEFT
-    ) -> str:
+    def validate_size(cls, value: str, pad_direction: PadDirection = PadDirection.LEFT) -> str:
         cls.update_schema()
         return validate_str_size(value, cls.size * 2, pad_direction=pad_direction)
 

--- a/eth_pydantic_types/hex/str.py
+++ b/eth_pydantic_types/hex/str.py
@@ -3,8 +3,8 @@ from typing import TYPE_CHECKING, Any, ClassVar, Optional, Union
 from hexbytes.main import HexBytes as BaseHexBytes
 from pydantic_core.core_schema import (
     ValidationInfo,
-    no_info_before_validator_function,
     str_schema,
+    no_info_before_validator_function,
     with_info_before_validator_function,
 )
 
@@ -26,10 +26,12 @@ if TYPE_CHECKING:
 class BaseHexStr(str, BaseHex):
     @classmethod
     def __get_pydantic_core_schema__(cls, value, handler=None):
-        return no_info_before_validator_function(cls.__eth_pydantic_validate__, str_schema())
+        return no_info_before_validator_function(
+            cls.__eth_pydantic_validate__, str_schema()
+        )
 
     @classmethod
-    def __eth_pydantic_validate__(cls, value):
+    def __eth_pydantic_validate__(cls, value, **kwargs):
         return value  # Override.
 
     @classmethod
@@ -70,7 +72,9 @@ class HexStr(BaseHexStr):
         )
 
     @classmethod
-    def __eth_pydantic_validate__(cls, value: Any, info: Optional[ValidationInfo] = None) -> str:
+    def __eth_pydantic_validate__(
+        cls, value: Any, info: Optional[ValidationInfo] = None, **kwargs
+    ) -> str:
         hex_str = cls.validate_hex(value)
         hex_value = hex_str[2:] if hex_str.startswith("0x") else hex_str
         sized_value = hex_value
@@ -97,19 +101,23 @@ class BoundHexStr(BaseHexStr):
         )
 
     @classmethod
-    def __eth_pydantic_validate__(cls, value: Any, info: Optional[ValidationInfo] = None) -> str:
+    def __eth_pydantic_validate__(
+        cls, value: Any, info: Optional[ValidationInfo] = None, **kwargs
+    ) -> str:
+        if not (pad := kwargs.pop("pad", None)):
+            # Integers are always padded to the left, but bytes-types are padded to the right
+            # to be ABI-encode compliant.
+            pad = PadDirection.LEFT if isinstance(value, int) else PadDirection.RIGHT
+
         hex_str = cls.validate_hex(value)
         hex_value = hex_str[2:] if hex_str.startswith("0x") else hex_str
-
-        # Integers are always padded to the left, but bytes-types are padded to the right
-        # to be ABI-encode compliant.
-        pad_direction = PadDirection.LEFT if isinstance(value, int) else PadDirection.RIGHT
-
-        sized_value = cls.validate_size(hex_value, pad_direction=pad_direction)
+        sized_value = cls.validate_size(hex_value, pad_direction=pad)
         return cls(f"0x{sized_value}")
 
     @classmethod
-    def validate_size(cls, value: str, pad_direction: PadDirection = PadDirection.LEFT) -> str:
+    def validate_size(
+        cls, value: str, pad_direction: PadDirection = PadDirection.LEFT
+    ) -> str:
         cls.update_schema()
         return validate_str_size(value, cls.size * 2, pad_direction=pad_direction)
 

--- a/eth_pydantic_types/utils.py
+++ b/eth_pydantic_types/utils.py
@@ -13,9 +13,7 @@ class PadDirection(str, Enum):
     RIGHT = "right"
 
 
-def validate_size(
-    value: "__SIZED_T", size: int, coerce: Optional[Callable] = None
-) -> "__SIZED_T":
+def validate_size(value: "__SIZED_T", size: int, coerce: Optional[Callable] = None) -> "__SIZED_T":
     if len(value) == size:
         return value
 
@@ -97,11 +95,7 @@ def _coerce_hexbytes_size(
     val_stripped = val.lstrip(b"\x00")
     num_zeroes = max(0, num_bytes - len(val_stripped))
     zeroes = b"\x00" * num_zeroes
-    return (
-        zeroes + val_stripped
-        if pad_direction is PadDirection.LEFT
-        else val_stripped + zeroes
-    )
+    return zeroes + val_stripped if pad_direction is PadDirection.LEFT else val_stripped + zeroes
 
 
 def validate_hex_str(value: str) -> str:

--- a/eth_pydantic_types/utils.py
+++ b/eth_pydantic_types/utils.py
@@ -13,7 +13,9 @@ class PadDirection(str, Enum):
     RIGHT = "right"
 
 
-def validate_size(value: "__SIZED_T", size: int, coerce: Optional[Callable] = None) -> "__SIZED_T":
+def validate_size(
+    value: "__SIZED_T", size: int, coerce: Optional[Callable] = None
+) -> "__SIZED_T":
     if len(value) == size:
         return value
 
@@ -39,7 +41,9 @@ def validate_bytes_size(
     value: bytes, size: int, pad_direction: PadDirection = PadDirection.LEFT
 ) -> bytes:
     return validate_size(
-        value, size, coerce=lambda v: _coerce_hexbytes_size(v, size, pad_direction=pad_direction)
+        value,
+        size,
+        coerce=lambda v: _coerce_hexbytes_size(v, size, pad_direction=pad_direction),
     )
 
 
@@ -51,7 +55,9 @@ def validate_str_size(
     value: str, size: int, pad_direction: PadDirection = PadDirection.LEFT
 ) -> str:
     return validate_size(
-        value, size, coerce=lambda v: _coerce_hexstr_size(v, size, pad_direction=pad_direction)
+        value,
+        size,
+        coerce=lambda v: _coerce_hexstr_size(v, size, pad_direction=pad_direction),
     )
 
 
@@ -91,7 +97,11 @@ def _coerce_hexbytes_size(
     val_stripped = val.lstrip(b"\x00")
     num_zeroes = max(0, num_bytes - len(val_stripped))
     zeroes = b"\x00" * num_zeroes
-    return zeroes + val_stripped if pad_direction is PadDirection.LEFT else val_stripped + zeroes
+    return (
+        zeroes + val_stripped
+        if pad_direction is PadDirection.LEFT
+        else val_stripped + zeroes
+    )
 
 
 def validate_hex_str(value: str) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,13 +33,122 @@ python_files = "test_*.py"
 testpaths = "tests"
 markers = "fuzzing: Run Hypothesis fuzz test suite"
 
-[tool.isort]
-line_length = 100
-force_grid_wrap = 0
-include_trailing_comma = true
-multi_line_output = 3
-use_parentheses = true
-skip = ["version.py"]
+
+[tool.ruff]
+target-version = "py39"
+line-length = 100
+
+[tool.ruff.lint]
+# Select rule categories to enforce
+select = [
+    # Core Python errors and style
+    "E",    # pycodestyle errors
+    "F",    # pyflakes
+    "W",    # pycodestyle warnings
+    "I",    # isort
+    "B",    # flake8-bugbear - common bugs/design issues
+    "C4",   # flake8-comprehensions - simplify comprehensions
+    "UP",   # pyupgrade - modern Python features/idioms
+    "RET",  # flake8-return - cleaner return statements
+    "SIM",  # flake8-simplify - code simplification
+    "S",    # flake8-bandit - security issues
+    "TCH",  # flake8-type-checking - type annotation improvements
+    "T10",  # flake8-debugger - detect debugger calls/imports
+    "FIX",  # flake8-fixme - detect FIXME, TODO, XXX comments
+]
+
+# Rules to ignore
+ignore = [
+    "E501",
+
+    # Specific bugbear issues
+    "B904",     # Use 'raise from' in except blocks
+    "B006",     # Mutable default arguments
+    "B007",     # Loop control variable not used within loop body
+    "B012",     # Jump statements in finally blocks
+    "B028",     # No explicit stacklevel in warnings
+
+    # FIXME/TODO comments - these are intentional markers for future work
+    "FIX002",   # Line contains TODO
+    "FIX004",   # Line contains HACK
+
+    # Code structure preferences
+    "SIM102",   # Use a single if statement instead of nested if statements
+    "SIM105",   # Use contextlib.suppress instead of try-except-pass
+    "SIM108",   # Use ternary operator instead of if-else block
+    "SIM113",   # Use enumerate instead of manually incrementing counter
+    "SIM114",   # If branches with identical arm bodies (combine with or)
+    "SIM115",   # Use context manager for opening files
+    "SIM116",   # Use dictionary instead of if-statements
+    "SIM117",   # Multiple with statements
+    "B018",     # Useless expression
+
+    # Return statement style
+    "RET501",   # Do not explicitly return None
+    "RET502",   # Implicit return at the end of function able to return non-None value
+    "RET503",   # Missing explicit return at the end of function able to return non-None value
+    "RET504",   # Unnecessary assignment before return
+    "RET505",   # Unnecessary else after return
+    "RET506",   # Unnecessary else after raise
+    "RET507",   # Unnecessary else after continue
+    "RET508",   # Unnecessary else after break
+
+    # Security issues (allow common patterns in the codebase)
+    "S101",     # Use of assert (many asserts are used for type checking)
+    "S102",     # Use of exec (needed in some specific places)
+    "S105",     # Hardcoded password string
+    "S110",     # Try-except-pass (common pattern for handling optional features)
+    "S112",     # Try-except-continue
+    "S113",     # Request without timeout
+    "S202",     # Tarfile unsafe members
+    "S307",     # Use of eval
+    "S311",     # Suspicious non-cryptographic random usage
+    "S603",     # Subprocess without shell=True
+    "S607",     # Start process with partial path
+
+    # Style/readability issues (improve incrementally)
+    "C416",     # Unnecessary comprehension (rewrite using list/set/dict)
+    "C408",     # Unnecessary dict() call (rewrite as literal)
+    "C417",     # Unnecessary map usage (replace with generator)
+    "C414",     # Unnecessary list/dict call within another function
+    "C401",     # Unnecessary generator (rewrite as comprehension)
+    "C409",     # Unnecessary literal within tuple/list/dict call
+    "C419",     # Unnecessary comprehension in call
+    "SIM101",   # Duplicate isinstance call
+    "SIM103",   # Needless boolean conversion
+    "SIM110",   # Reimplemented builtin
+    "SIM118",   # Use 'key in dict' instead of 'key in dict.keys()'
+    "SIM401",   # Use dict.get instead of if-else block
+    "SIM910",   # Use dict.get(key) instead of dict.get(key, None)
+    "TC001",    # Move application import into type-checking block
+    "TC003",    # Move standard library import into type-checking block
+    "TC006",    # Add quotes to type expression in `typing.cast()`
+    "UP028",    # Replace yield over for loop with yield from
+]
+
+[tool.ruff.lint.per-file-ignores]
+"**/tests/**/*.py" = [
+    "D",        # Don't require docstrings in tests
+    "E501",     # Line length in tests is less critical
+    "S101",     # Allow assert in tests
+    "B011",     # Allow assert False in tests (common pattern)
+]
+"**/conftest.py" = [
+    "F401",     # Unused imports in conftest.py are often for fixtures
+    "F841",     # Allow unused variables in conftest (often for fixture side effects)
+]
+
+[tool.ruff.lint.pydocstyle]
+convention = "google"
+
+[tool.ruff.lint.isort]
+known-first-party = ["eth_pydantic_types"]
+
+[tool.ruff.format]
+quote-style = "double"
+line-ending = "auto"
+indent-style = "space"
+docstring-code-format = true
 
 [tool.mdformat]
 number = true

--- a/setup.py
+++ b/setup.py
@@ -16,15 +16,9 @@ extras_require = {
         "eth-hash[pycryptodome]",  # For backends to work
     ],
     "lint": [
-        "black>=25.1.0,<26",  # Auto-formatter and linter
-        "mypy>=1.15.0,<2",  # Static type analyzer
+        "ruff>=0.12.0",  # Unified linter and formatter
+        "mypy>=1.16.1,<2",  # Static type analyzer
         "types-setuptools",  # Needed for mypy type shed
-        "flake8>=7.2.0,<8",  # Style linter
-        "flake8-breakpoint>=1.1.0,<2",  # Detect breakpoints left in code
-        "flake8-print>=5.0.0,<6",  # Detect print statements left in code
-        "flake8-pydantic",  # For detecting issues with Pydantic models
-        "flake8-type-checking",  # Detect imports to move in/out of type-checking blocks
-        "isort>=6.0.1,<7",  # Import sorting linter
         "mdformat>=0.7.22",  # Auto-formatter for markdown
         "mdformat-gfm>=0.3.5",  # Needed for formatting GitHub-flavored markdown
         "mdformat-frontmatter>=0.4.1",  # Needed for frontmatters-style headers in issue templates

--- a/tests/test_hex.py
+++ b/tests/test_hex.py
@@ -85,9 +85,7 @@ class TestHexBytes:
     def test_model_dump(self, bytes32str):
         model = BytesModel(value=bytes32str)
         actual = model.model_dump()
-        expected = {
-            "value": "0x9b70bd98ccb5b6434c2ead14d68d15f392435a06ff469f8d1f8cf38b2ae0b0e2"
-        }
+        expected = {"value": "0x9b70bd98ccb5b6434c2ead14d68d15f392435a06ff469f8d1f8cf38b2ae0b0e2"}
         assert actual == expected
 
     def test_from_bytes(self):
@@ -102,9 +100,7 @@ class TestHexBytes:
             @field_validator("my_bytes", mode="before")
             @classmethod
             def validate_value(cls, value, info):
-                return HexBytes20.__eth_pydantic_validate__(
-                    value, pad=PadDirection.RIGHT
-                )
+                return HexBytes20.__eth_pydantic_validate__(value, pad=PadDirection.RIGHT)
 
         model = MyModel(my_bytes=1)
         assert model.my_bytes.startswith(HexBytes(1))
@@ -149,9 +145,7 @@ class TestHexStr:
     def test_model_dump(self, bytes32str):
         model = StrModel(value=bytes32str)
         actual = model.model_dump()
-        expected = {
-            "value": "0x9b70bd98ccb5b6434c2ead14d68d15f392435a06ff469f8d1f8cf38b2ae0b0e2"
-        }
+        expected = {"value": "0x9b70bd98ccb5b6434c2ead14d68d15f392435a06ff469f8d1f8cf38b2ae0b0e2"}
         assert actual == expected
 
         model = StrModel(value=3)
@@ -185,9 +179,7 @@ class TestHexStr:
             def validate_value(cls, value, info):
                 field_type = cls.model_fields[info.field_name].annotation
                 assert field_type  # For Mypy
-                return field_type.__eth_pydantic_validate__(
-                    value, pad=PadDirection.RIGHT
-                )
+                return field_type.__eth_pydantic_validate__(value, pad=PadDirection.RIGHT)
 
         model = MyModel(my_str=1)
         assert model.my_str.startswith("0x01")
@@ -240,9 +232,7 @@ class TestSized:
         for addr in (address, HexBytes(address)):
             model = MyModel(my_address=addr)
             assert len(model.my_address) == 20
-            assert model.my_address == HexBytes(
-                "0xcafac3dd18ac6c6e92c921884f9e4176737c052c"
-            )
+            assert model.my_address == HexBytes("0xcafac3dd18ac6c6e92c921884f9e4176737c052c")
 
     def test_schema(self):
         actual = SizedModel.model_json_schema()

--- a/tests/test_hex.py
+++ b/tests/test_hex.py
@@ -3,7 +3,7 @@ from typing import ClassVar
 import pytest
 from eth_utils import to_hex
 from hexbytes import HexBytes as BaseHexBytes
-from pydantic import BaseModel, ValidationError
+from pydantic import BaseModel, ValidationError, field_validator
 
 from eth_pydantic_types.hex import (
     BoundHexBytes,
@@ -16,6 +16,7 @@ from eth_pydantic_types.hex import (
     HexStr20,
     HexStr32,
 )
+from eth_pydantic_types.utils import PadDirection
 
 
 class BytesModel(BaseModel):
@@ -84,13 +85,29 @@ class TestHexBytes:
     def test_model_dump(self, bytes32str):
         model = BytesModel(value=bytes32str)
         actual = model.model_dump()
-        expected = {"value": "0x9b70bd98ccb5b6434c2ead14d68d15f392435a06ff469f8d1f8cf38b2ae0b0e2"}
+        expected = {
+            "value": "0x9b70bd98ccb5b6434c2ead14d68d15f392435a06ff469f8d1f8cf38b2ae0b0e2"
+        }
         assert actual == expected
 
     def test_from_bytes(self):
         value = b"\x101\xf0\xc9\xacT\xdc\xb6KO\x12\x1a'\x95|\x14&<\\\xb4"
         model = BytesModel(value=value)
         assert model.value == HexBytes(value)
+
+    def test_right_pad(self):
+        class MyModel(BaseModel):
+            my_bytes: HexBytes20
+
+            @field_validator("my_bytes", mode="before")
+            @classmethod
+            def validate_value(cls, value, info):
+                return HexBytes20.__eth_pydantic_validate__(
+                    value, pad=PadDirection.RIGHT
+                )
+
+        model = MyModel(my_bytes=1)
+        assert model.my_bytes.startswith(HexBytes(1))
 
 
 class TestHexStr:
@@ -132,7 +149,9 @@ class TestHexStr:
     def test_model_dump(self, bytes32str):
         model = StrModel(value=bytes32str)
         actual = model.model_dump()
-        expected = {"value": "0x9b70bd98ccb5b6434c2ead14d68d15f392435a06ff469f8d1f8cf38b2ae0b0e2"}
+        expected = {
+            "value": "0x9b70bd98ccb5b6434c2ead14d68d15f392435a06ff469f8d1f8cf38b2ae0b0e2"
+        }
         assert actual == expected
 
         model = StrModel(value=3)
@@ -157,10 +176,21 @@ class TestHexStr:
             assert len(model.my_address) == 42
             assert model.my_address == "0xcafac3dd18ac6c6e92c921884f9e4176737c052c"
 
-        def test_from_bytes(self):
-            value = b"\x101\xf0\xc9\xacT\xdc\xb6KO\x12\x1a'\x95|\x14&<\\\xb4"
-            model = StrModel(value=value)
-            assert model.value == HexBytes(value)
+    def test_right_pad(self):
+        class MyModel(BaseModel):
+            my_str: HexStr20
+
+            @field_validator("my_str", mode="before")
+            @classmethod
+            def validate_value(cls, value, info):
+                field_type = cls.model_fields[info.field_name].annotation
+                assert field_type  # For Mypy
+                return field_type.__eth_pydantic_validate__(
+                    value, pad=PadDirection.RIGHT
+                )
+
+        model = MyModel(my_str=1)
+        assert model.my_str.startswith("0x01")
 
 
 class TestHexBytes32:
@@ -210,7 +240,9 @@ class TestSized:
         for addr in (address, HexBytes(address)):
             model = MyModel(my_address=addr)
             assert len(model.my_address) == 20
-            assert model.my_address == HexBytes("0xcafac3dd18ac6c6e92c921884f9e4176737c052c")
+            assert model.my_address == HexBytes(
+                "0xcafac3dd18ac6c6e92c921884f9e4176737c052c"
+            )
 
     def test_schema(self):
         actual = SizedModel.model_json_schema()


### PR DESCRIPTION
### What I did

Adds support for setting the padding in pydantic validators

```python
        class MyModel(BaseModel):
            my_str: HexStr20

            @field_validator("my_str", mode="before")
            @classmethod
            def validate_value(cls, value, info):
                return HexStr20.__eth_pydantic_validate__(value, pad=PadDirection.RIGHT)
```

I wish there was an even nicer way but there kinda isn't; this works for now and unblocks me

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
