### PR TITLE
fix: regular HexInt should not pad (even for even)

### DIFF
--- a/eth_pydantic_types/hex/int.py
+++ b/eth_pydantic_types/hex/int.py
@@ -97,7 +97,9 @@ class BoundHexInt(BaseHexInt):
         )
 
         # NOTE: Integers should always pad left; else the value increases.
-        schema["serialization"] = create_hex_serializer(size=cls.size, pad=PadDirection.LEFT)
+        schema["serialization"] = create_hex_serializer(
+            size=cls.size, pad=PadDirection.LEFT, force_even_length=False
+        )
 
         return schema
 

--- a/eth_pydantic_types/serializers.py
+++ b/eth_pydantic_types/serializers.py
@@ -8,24 +8,35 @@ from eth_pydantic_types.utils import PadDirection, validate_str_size
 def serialize_hex(
     value: Union[int, bytes],
     size: Optional[int] = None,
-    pad: PadDirection = PadDirection.LEFT,
+    pad: Optional[PadDirection] = None,
+    force_even_length: Optional[bool] = None,
 ) -> str:
     hex_value = value.hex() if isinstance(value, bytes) else hex(value)
     hex_value = hex_value[2:] if hex_value.startswith("0x") else hex_value
 
+    if pad is not None and force_even_length is not None:
+        # If padding at all and force_even_length not specified, assume True.
+        force_even_length = True
+
     # Ensure even number of left-padded zeroes.
-    if len(hex_value) % 2 != 0:
+    if force_even_length and len(hex_value) % 2 != 0:
         hex_value = f"0{hex_value}"
 
-    if size is not None:
+    if size is not None and pad is not None:
         hex_value = validate_str_size(hex_value, size * 2, pad_direction=pad)
 
     return f"0x{hex_value}"
 
 
-def create_hex_serializer(size: Optional[int] = None, pad: PadDirection = PadDirection.LEFT):
+def create_hex_serializer(
+    size: Optional[int] = None,
+    pad: Optional[PadDirection] = None,
+    force_even_length: Optional[bool] = None,
+):
     return plain_serializer_function_ser_schema(
-        function=lambda value: serialize_hex(value, size=size, pad=pad)
+        function=lambda value: serialize_hex(
+            value, size=size, pad=pad, force_even_length=force_even_length
+        )
     )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,6 @@ python_files = "test_*.py"
 testpaths = "tests"
 markers = "fuzzing: Run Hypothesis fuzz test suite"
 
-
 [tool.ruff]
 target-version = "py39"
 line-length = 100

--- a/tests/hex/test_int.py
+++ b/tests/hex/test_int.py
@@ -39,10 +39,14 @@ class TestHexInt:
         assert actual["properties"]["value"]["type"] == "integer"
         assert actual["properties"]["value"]["examples"][0].startswith("0x")
 
-    def test_model_dump(self):
-        model = IntModel(value=10)
+    @pytest.mark.parametrize("value", ("0xa", "0x0a", 10))
+    def test_model_dump(self, value):
+        model = IntModel(value=value)
         actual = model.model_dump()
-        assert actual == {"value": "0x0a"}
+
+        # Notice the odd number of bytes here; that is expected for HexInt.
+        # It is less storage; we know what number it is.
+        assert actual == {"value": "0xa"}
 
     @pytest.mark.parametrize("value", (-1, 2 * 8**256))
     def test_out_of_bounds(self, value):


### PR DESCRIPTION
### What I did

Regular HexInt is not supposed to pad at all. It still was padding to become an even number of bytes, but it shouldn't even do that for HexInt because typically those are stored in minimal form (see U256 types).

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
