### PR TITLE
fix: Add type hints to HexBytes to provide better type support

### DIFF
--- a/tests/hex/test_typehints.py
+++ b/tests/hex/test_typehints.py
@@ -1,0 +1,8 @@
+from typing_extensions import assert_type
+
+from eth_pydantic_types.hex.bytes import HexBytes32
+
+
+def test_hexbytes_fromhex():
+    x = HexBytes32.fromhex("00" * 32)
+    assert_type(x, HexBytes32)

--- a/tests/hex/test_typehints.py
+++ b/tests/hex/test_typehints.py
@@ -6,3 +6,4 @@ from eth_pydantic_types.hex.bytes import HexBytes32
 def test_hexbytes_fromhex():
     x = HexBytes32.fromhex("00" * 32)
     assert_type(x, HexBytes32)
+    assert isinstance(x, HexBytes32)


### PR DESCRIPTION
### What I did

This PR adds some extra type hints for the HexBytes* family of classes to provide better typing support when developing.

### How I did it

Followed the standard methodology for adding such type annotations to class methods: https://typing.python.org/en/latest/spec/generics.html#use-in-classmethod-signatures

I avoided the use of the newer `typing.Self` type to be backwards compatible with older Python versions.

An extra testcase has been added to verify the fix. Since this is a typing fix, you need to a run mypy to run the type hint assertions: 
```bash
mypy tests/
```

### How to verify it
On main:
```bash
mypy -c 'from typing_extensions import assert_type; from eth_pydantic_types.hex.bytes import HexBytes32; assert_type(HexBytes32.fromhex("00"), HexBytes32)'
<string>:1: error: Expression is of type "HexBytes", not "BoundHexBytes"  [assert-type]
Found 1 error in 1 file (checked 1 source file)
```

on this branch the error no longer occurs:
```
mypy -c 'from typing_extensions import assert_type; from eth_pydantic_types.hex.bytes import HexBytes32; assert_type(HexBytes32.fromhex("00"), HexBytes32)'
Success: no issues found in 1 source file
```

### Checklist

- [x] All changes are completed
- [x] New test cases have been added
- [ ] Documentation has been updated
